### PR TITLE
Remove extension configuration

### DIFF
--- a/Classes/Utility/LogParserUtility.php
+++ b/Classes/Utility/LogParserUtility.php
@@ -2,9 +2,6 @@
 
 namespace Xima\XimaTypo3Mailcatcher\Utility;
 
-use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
-use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Crypto\Random;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -34,16 +31,13 @@ class LogParserUtility
 
     protected function loadLogFile(): void
     {
-        /** @var ExtensionConfiguration $extensionConfiguration */
-        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
-        $logPath = $extensionConfiguration->get('xima_typo3_mailcatcher', 'logPath');
-        $absolutePath = Environment::getProjectPath() . $logPath;
+        $mboxFile = $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_mbox_file'] ?? '';
 
-        if (!file_exists($absolutePath)) {
+        if (!file_exists($mboxFile)) {
             return;
         }
 
-        $this->fileContent = (string)file_get_contents($absolutePath);
+        $this->fileContent = (string)file_get_contents($mboxFile);
     }
 
     protected function extractMessages(): void
@@ -270,21 +264,14 @@ class LogParserUtility
         return unlink($file);
     }
 
-    /**
-     * @throws ExtensionConfigurationExtensionNotConfiguredException
-     * @throws ExtensionConfigurationPathDoesNotExistException
-     */
     protected function emptyLogFile(): void
     {
-        /** @var ExtensionConfiguration $extensionConfiguration */
-        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
-        $logPath = $extensionConfiguration->get('xima_typo3_mailcatcher', 'logPath');
-        $absolutePath = Environment::getProjectPath() . $logPath;
+        $mboxFile = $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_mbox_file'] ?? '';
 
-        if (!file_exists($absolutePath)) {
+        if (!file_exists($mboxFile)) {
             return;
         }
 
-        file_put_contents($absolutePath, '');
+        file_put_contents($mboxFile, '');
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mail Catcher
 
-This TYPO3 extension adds a module to view emails that were printed to file.
+This TYPO3 extension adds a backend module to view emails that were send to file.
 
 ![backend_module](Documentation/example_backend_module.jpg)
 
@@ -12,15 +12,11 @@ composer require xima/xima-typo3-mailcatcher
 
 ## Configuration
 
-To prevent TYPO3 from sending emails, change the transport to `mbox` ([Mail-API](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Mail/Index.html#mbox)). This way TYPO3 writes the outgoing emails to a log file that you can specify via `transport_mbox_file`. The path musst be absolute.
+No extension configuration needed!
+
+To prevent TYPO3 from sending emails, change the transport to `mbox` (see official [TYPO3 Mail-API](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Mail/Index.html#mbox)). This way TYPO3 writes the outgoing emails to a log file that you can specify via `transport_mbox_file`. The path musst be absolute.
 
 ```
 $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport'] = 'mbox';
 $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_mbox_file'] = \TYPO3\CMS\Core\Core\Environment::getProjectPath() . '/var/log/mail.log';
-```
-
-In the configuration of this extension, adjust the path to the one, you just selected. This path musst be relative.
-
-```
-$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['xima_typo3_mailcatcher']['logPath'] = '/var/log/mail.log'
 ```

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -128,6 +128,10 @@
 </div>
 
 <style>
+    :root {
+        --panel-heading-bg: #eeeeee;
+    }
+
 	.tab-header {
 		background: #fff;
 		padding: 10px;

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -8,9 +8,7 @@
 	<div class="row justify-content-md-center">
 		<div class="col">
 			<ul class="list-group">
-				<li class="list-group-item">Inbox (
-					<span class="message-count">{mails->f:count()}</span>
-					)
+				<li class="list-group-item">Inbox (<span class="message-count">{mails->f:count()}</span>)
 				</li>
 			</ul>
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,2 +1,0 @@
-# cat=basic/enable/050; type=string; label=Log path: The path where the python dev mailer outputs the catched mails
-logPath=/var/log/mail.log

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -2,7 +2,7 @@
 
 $EM_CONF[$_EXTKEY] = [
     'title' => 'XIMA Mail Catcher',
-    'description' => 'Display mails that were send to log file',
+    'description' => 'Backend module to display mails that were send to log file',
     'category' => 'backend',
     'author' => 'Maik Schneider',
     'author_email' => 'maik.scheider@xima.de',


### PR DESCRIPTION
The `log_path` setting of this extension is identical to the TYPO3 setting `transport_mbox_file`. There is no need to have a separate setting.