### PR TITLE
feat: do not load module in production

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,31 +1,33 @@
 <?php
 
-$iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
-$iconRegistry->registerIcon(
-    'module-mailcatcher',
-    \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
-    ['source' => 'EXT:xima_typo3_mailcatcher/Resources/Public/Icons/Extension.svg']
-);
+if (isset($GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport']) && $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport'] === 'mbox') {
+    $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
+    $iconRegistry->registerIcon(
+        'module-mailcatcher',
+        \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        ['source' => 'EXT:xima_typo3_mailcatcher/Resources/Public/Icons/Extension.svg']
+    );
 
-$versionNumberUtility = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Utility\VersionNumberUtility::class);
-$version = $versionNumberUtility->convertVersionStringToArray($versionNumberUtility->getNumericTypo3Version());
+    $versionNumberUtility = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Utility\VersionNumberUtility::class);
+    $version = $versionNumberUtility->convertVersionStringToArray($versionNumberUtility->getNumericTypo3Version());
 
-$controllerName = \Xima\XimaTypo3Mailcatcher\Controller\LegacyBackendController::class;
-if ($version['version_main'] >= 11) {
-    $controllerName = \Xima\XimaTypo3Mailcatcher\Controller\BackendController::class;
+    $controllerName = \Xima\XimaTypo3Mailcatcher\Controller\LegacyBackendController::class;
+    if ($version['version_main'] >= 11) {
+        $controllerName = \Xima\XimaTypo3Mailcatcher\Controller\BackendController::class;
+    }
+
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
+        'XimaTypo3Mailcatcher',
+        'system',
+        'mails',
+        '',
+        [
+            $controllerName => 'index',
+        ],
+        [
+            'access' => 'admin',
+            'iconIdentifier' => 'module-mailcatcher',
+            'labels' => 'LLL:EXT:xima_typo3_mailcatcher/Resources/Private/Language/locallang_mod.xlf',
+        ]
+    );
 }
-
-\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-    'XimaTypo3Mailcatcher',
-    'system',
-    'mails',
-    '',
-    [
-        $controllerName => 'index',
-    ],
-    [
-        'access' => 'admin',
-        'iconIdentifier' => 'module-mailcatcher',
-        'labels' => 'LLL:EXT:xima_typo3_mailcatcher/Resources/Private/Language/locallang_mod.xlf',
-    ]
-);


### PR DESCRIPTION
This extension does only work if the TYPO3 Mail configuration is set to `mbox`. In production environment the backend module is not needed. This PR prevents the registration of the module and custom icon.