### PR TITLE
fix: prevent autowiring of not supported controller in v10

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (
+    ContainerConfigurator $containerConfigurator,
+    ContainerBuilder $containerBuilder
+): void {
+    $services = $containerConfigurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure();
+
+    $excludes = ['../Classes/Domain/Model/'];
+
+    // Prevent autowiring of unsupported controller (v10 is legacy)
+    if (!$containerBuilder->hasDefinition(\TYPO3\CMS\Backend\Template\ModuleTemplateFactory::class)) {
+        $excludes[] = '../Classes/Controller/BackendController.php';
+    } else {
+        $excludes[] = '../Classes/Controller/LegacyBackendController.php';
+    }
+
+    $services->load('Xima\\XimaTypo3Mailcatcher\\', '../Classes/')
+        ->exclude($excludes);
+};

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,9 +1,0 @@
-services:
-  _defaults:
-    autowire: true
-    autoconfigure: true
-    public: false
-
-  Xima\XimaTypo3Mailcatcher\:
-    resource: '../Classes/*'
-    exclude: '../Classes/Domain/Model/*'


### PR DESCRIPTION
Use `Services.php` to conditionally register files for dependency injection. Simple check if the `ModuleTemplateFactory` class is loaded to test of the `BackendController.php` or the `LegacyBackendController.php` should be included.

Fixes #13 