### PR TITLE
fix: hide module if mbox is not set in v12

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -2,7 +2,9 @@
 
 use Xima\XimaTypo3Mailcatcher\Controller\BackendController;
 
-return [
+$isMbox = isset($GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport']) && $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport'] === 'mbox';
+
+return $isMbox ? [
     'system_mails' => [
         'parent' => 'system',
         'position' => [],
@@ -17,4 +19,4 @@ return [
             ],
         ],
     ],
-];
+] : [];


### PR DESCRIPTION
In TYPO3 version <12, the backend module registration was done in `ext_tables.php`. Now, `Configuration/Backend/Modules.php` is used. This PR adds the check for `$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport'] === 'mbox'` to the `Modules.php` as well.