### PR TITLE
Remove duplicate decoding

### DIFF
--- a/Classes/Utility/LogParserUtility.php
+++ b/Classes/Utility/LogParserUtility.php
@@ -52,9 +52,6 @@ class LogParserUtility
             $boundaries
         );
 
-        // decode whole file
-        $this->fileContent = quoted_printable_decode($this->fileContent);
-
         if (!isset($boundaries[1])) {
             return;
         }


### PR DESCRIPTION
Before using [zbateson/mail-mime-parser](https://github.com/zbateson/mail-mime-parser) a decoding of the mail log file was necessary. This is now done by the library.

Resolves #17 