### PR TITLE
Parse single format mails

### DIFF
--- a/Tests/Fixtures/TestMailTemplate.html
+++ b/Tests/Fixtures/TestMailTemplate.html
@@ -1,1 +1,3 @@
-https://domain/sign-in/registration/confirmation?tx_getaccess_confirmation%5Baction%5D=user&tx_getaccess_confirmation%5Bcontroller%5D=Confirmation&tx_getaccess_confirmation%5Bhash%5D=2720ba93a3007066&cHash=3179e61306999063853b2247a1bd4d
+<h1>Hallo Welt!</h1><br />
+<br />
+<a href="#">https://domain/sign-in/registration/confirmation?tx_getaccess_confirmation%5Baction%5D=user&tx_getaccess_confirmation%5Bcontroller%5D=Confirmation&tx_getaccess_confirmation%5Bhash%5D=2720ba93a3007066&cHash=3179e61306999063853b2247a1bd4d</a>

--- a/Tests/Fixtures/TestMailTemplate.txt
+++ b/Tests/Fixtures/TestMailTemplate.txt
@@ -1,1 +1,3 @@
+Hallo Welt!
+
 https://domain/sign-in/registration/confirmation?tx_getaccess_confirmation%5Baction%5D=user&tx_getaccess_confirmation%5Bcontroller%5D=Confirmation&tx_getaccess_confirmation%5Bhash%5D=2720ba93a3007066&cHash=3179e61306999063853b2247a1bd4d

--- a/Tests/Functional/Utility/LogParserUtilityTest.php
+++ b/Tests/Functional/Utility/LogParserUtilityTest.php
@@ -64,20 +64,36 @@ class LogParserUtilityTest extends FunctionalTestCase
             'format' => FluidEmail::FORMAT_BOTH,
         ];
 
+        $htmlOnlyMail = $defaultMail;
+        $htmlOnlyMail['format'] = FluidEmail::FORMAT_HTML;
+
+        $plainOnlyMail = $defaultMail;
+        $plainOnlyMail['format'] = FluidEmail::FORMAT_PLAIN;
+
         return [
             [
                 [$defaultMail],
             ],
             [
                 [
+                    $plainOnlyMail,
+                    $plainOnlyMail,
                     $defaultMail,
-                    $defaultMail,
+                    $plainOnlyMail,
                 ],
             ],
             [
                 [
+                    $htmlOnlyMail,
+                    $htmlOnlyMail,
                     $defaultMail,
+                    $htmlOnlyMail,
                 ],
+            ],
+            [
+                [$defaultMail],
+                [$htmlOnlyMail],
+                [$plainOnlyMail],
             ],
         ];
     }
@@ -89,7 +105,7 @@ class LogParserUtilityTest extends FunctionalTestCase
      */
     public function testEmailEncoding(array $exampleMails): void
     {
-        foreach ($exampleMails as $key => $exampleMail) {
+        foreach ($exampleMails as $exampleMail) {
             $this->createTestMail($exampleMail);
         }
 


### PR DESCRIPTION
The log parser needed the `boundary` keyword to distinguish between single mails. Unfortunately, this keyword is only send when both formats (plain and html) are used. This PR removes the need for this by using `To: xxx \r\nFrom: xxx\rnSubject:` as separator.

resolves #24 